### PR TITLE
OpenAI azure 服务的几个环境变量名称再统一规范一下

### DIFF
--- a/code365scripts.openai/code365scripts.openai.psm1
+++ b/code365scripts.openai/code365scripts.openai.psm1
@@ -209,7 +209,7 @@ function New-ChatGPTConversation {
         if ($azure) {
             $api_key = if ($api_key) { $api_key } else { if ($env:OPENAI_API_KEY_Azure) { $env:OPENAI_API_KEY_Azure } else { $env:OPENAI_API_KEY } }
             $engine = if ($engine) { $engine } else { if ($env:OPENAI_CHAT_ENGINE_Azure) { $env:OPENAI_CHAT_ENGINE_Azure }else { "gpt-3.5-turbo" } }
-            $endpoint = if ($endpoint) { $endpoint } else { "{0}openai/deployments/$engine/chat/completions?api-version=2023-03-15-preview" -f $env:OPENAI_ENDPOINT_AZURE }
+            $endpoint = if ($endpoint) { $endpoint } else { "{0}openai/deployments/$engine/chat/completions?api-version=2023-03-15-preview" -f $env:OPENAI_ENDPOINT_Azure }
         }
         else {
             $api_key = if ($api_key) { $api_key } else { $env:OPENAI_API_KEY }


### PR DESCRIPTION
Fixes #1 因为Powershell 其实在读取环境变量时是不区分大小写的，所以其实无所谓，但统一了一下Azure这个后缀也好