### PR TITLE
改成用 invoke-webrequest后，如果传输内容比较多，会有一个进度条一闪而过，如何去掉这个进度条？

### DIFF
--- a/code365scripts.openai/Private/Invoke-UniWebRequest.ps1
+++ b/code365scripts.openai/Private/Invoke-UniWebRequest.ps1
@@ -4,7 +4,9 @@ function Invoke-UniWebRequest {
         [hashtable]$params
     )
 
+    $ProgressPreference = 'SilentlyContinue'
     $response = Invoke-WebRequest @params -ContentType "application/json;charset=utf-8"
+    $ProgressPreference = 'Continue'
 
     if (($PSVersionTable['PSVersion'].Major -ge 6) -or ($response.Headers['Content-Type'] -match 'charset=utf-8')) {
         return $response.Content | ConvertFrom-Json


### PR DESCRIPTION
Fixes #208